### PR TITLE
refactor: extract babel setup helper into own module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 'use strict';
 
-const setupBabel = require('./setup-babel');
+const setupBabel = require('./private/setup-babel');
 
 module.exports = {
   name: '@babel-decorators/babel-transforms',

--- a/index.js
+++ b/index.js
@@ -1,35 +1,7 @@
 /* eslint-env node */
 'use strict';
 
-const path = require('path');
-const VersionChecker = require('ember-cli-version-checker');
-
-function requireTransform(transformName) {
-  let plugin = require(transformName);
-
-  plugin = plugin.__esModule ? plugin.default : plugin;
-
-  // adding `baseDir` ensures that broccoli-babel-transpiler does not
-  // issue a warning and opt out of caching
-  const pluginPath = require.resolve(`${transformName}/package`);
-  const pluginBaseDir = path.dirname(pluginPath);
-  plugin.baseDir = () => pluginBaseDir;
-
-  return plugin;
-}
-
-function hasPlugin(plugins, name) {
-  for (const maybePlugin of plugins) {
-    const plugin = Array.isArray(maybePlugin) ? maybePlugin[0] : maybePlugin;
-    const pluginName = typeof plugin === 'string' ? plugin : plugin.name;
-
-    if (pluginName === name) {
-      return true;
-    }
-  }
-
-  return false;
-}
+const setupBabel = require('./setup-babel');
 
 module.exports = {
   name: '@babel-decorators/babel-transforms',
@@ -45,40 +17,7 @@ module.exports = {
       parentOptions['@ember-decorators/babel-transforms'] || {});
 
     if (!this._registeredWithBabel && !ownOptions.disable) {
-      const checker = new VersionChecker(this.parent).for(
-        'ember-cli-babel',
-        'npm'
-      );
-
-      if (checker.satisfies('^6.0.0-beta.1')) {
-        const TransformDecoratorsLegacy = requireTransform(
-          'babel-plugin-transform-decorators-legacy'
-        );
-        const TransformClassProperties = requireTransform(
-          'babel-plugin-transform-class-properties'
-        );
-
-        // Create babel options if they do not exist
-        parentOptions.babel = parentOptions.babel || {};
-
-        // Create and pull off babel plugins
-        const plugins = (parentOptions.babel.plugins =
-          parentOptions.babel.plugins || []);
-
-        if (!hasPlugin(plugins, 'transform-decorators-legacy')) {
-          // unshift the transform because it always must come before class properties
-          plugins.unshift(TransformDecoratorsLegacy);
-        }
-
-        if (!hasPlugin('transform-class-properties')) {
-          plugins.push(TransformClassProperties);
-        }
-      } else {
-        parent.project.ui.writeWarnLine(
-          '@ember-decorators/babel-transforms: You are using an unsupported ember-cli-babel version, decorator/class-property transforms will not be included automatically'
-        );
-      }
-
+      setupBabel(parent);
       this._registeredWithBabel = true;
     }
   }

--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ module.exports = {
   name: '@babel-decorators/babel-transforms',
 
   included(parent) {
-    this._super.included.apply(this, arguments);
+    this._super &&
+      this._super.included &&
+      this._super.included.apply(this, arguments);
 
     // Create parent options, if they do nox exist
     const parentOptions = (parent.options = parent.options || {});

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
   included(parent) {
     this._super.included.apply(this, arguments);
 
-    // Create parent options, if they do nox exist
+    // Create parent options, if they do not exist
     const parentOptions = (parent.options = parent.options || {});
 
     // Create our own options, if they do not exist

--- a/index.js
+++ b/index.js
@@ -35,9 +35,7 @@ module.exports = {
   name: '@babel-decorators/babel-transforms',
 
   included(parent) {
-    this._super &&
-      this._super.included &&
-      this._super.included.apply(this, arguments);
+    this._super.included.apply(this, arguments);
 
     // Create parent options, if they do nox exist
     const parentOptions = (parent.options = parent.options || {});

--- a/private/setup-babel.js
+++ b/private/setup-babel.js
@@ -1,6 +1,18 @@
 /* eslint-env node */
 'use strict';
 
+/**
+ * Please *do not* import this file in your project. We put this here for
+ * backwards compatibility reasons with the ember-decorators main package.
+ *
+ * This is explicitly private API and not intended for use inside third-party
+ * addons.
+ *
+ * If you find yourself in need of importing this file, because babel-transforms
+ * does not serve your special use case, please open an issue instead and let us
+ * find a solution. :)
+ */
+
 const path = require('path');
 const VersionChecker = require('ember-cli-version-checker');
 

--- a/setup-babel.js
+++ b/setup-babel.js
@@ -1,0 +1,68 @@
+/* eslint-env node */
+'use strict';
+
+const path = require('path');
+const VersionChecker = require('ember-cli-version-checker');
+
+function requireTransform(transformName) {
+  let plugin = require(transformName);
+
+  plugin = plugin.__esModule ? plugin.default : plugin;
+
+  // adding `baseDir` ensures that broccoli-babel-transpiler does not
+  // issue a warning and opt out of caching
+  const pluginPath = require.resolve(`${transformName}/package`);
+  const pluginBaseDir = path.dirname(pluginPath);
+  plugin.baseDir = () => pluginBaseDir;
+
+  return plugin;
+}
+
+function hasPlugin(plugins, name) {
+  for (const maybePlugin of plugins) {
+    const plugin = Array.isArray(maybePlugin) ? maybePlugin[0] : maybePlugin;
+    const pluginName = typeof plugin === 'string' ? plugin : plugin.name;
+
+    if (pluginName === name) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+module.exports = function setupBabel(parent) {
+  // Create parent options, if they do nox exist
+  const parentOptions = (parent.options = parent.options || {});
+
+  const checker = new VersionChecker(parent).for('ember-cli-babel', 'npm');
+
+  if (checker.satisfies('^6.0.0-beta.1')) {
+    const TransformDecoratorsLegacy = requireTransform(
+      'babel-plugin-transform-decorators-legacy'
+    );
+    const TransformClassProperties = requireTransform(
+      'babel-plugin-transform-class-properties'
+    );
+
+    // Create babel options if they do not exist
+    parentOptions.babel = parentOptions.babel || {};
+
+    // Create and pull off babel plugins
+    const plugins = (parentOptions.babel.plugins =
+      parentOptions.babel.plugins || []);
+
+    if (!hasPlugin(plugins, 'transform-decorators-legacy')) {
+      // unshift the transform because it always must come before class properties
+      plugins.unshift(TransformDecoratorsLegacy);
+    }
+
+    if (!hasPlugin('transform-class-properties')) {
+      plugins.push(TransformClassProperties);
+    }
+  } else {
+    parent.project.ui.writeWarnLine(
+      '@ember-decorators/babel-transforms: You are using an unsupported ember-cli-babel version, decorator/class-property transforms will not be included automatically'
+    );
+  }
+};

--- a/setup-babel.js
+++ b/setup-babel.js
@@ -32,7 +32,7 @@ function hasPlugin(plugins, name) {
 }
 
 module.exports = function setupBabel(parent) {
-  // Create parent options, if they do nox exist
+  // Create parent options, if they do not exist
   const parentOptions = (parent.options = parent.options || {});
 
   const checker = new VersionChecker(parent).for('ember-cli-babel', 'npm');


### PR DESCRIPTION
While working on https://github.com/ember-decorators/ember-decorators/pull/182#issuecomment-347255423 I hit a wall when trying to call this addon's `included` hook. This PR originally attempted to only call `this._super.included`, if it is set, which feels really hacky and needlessly convoluted.

Now it extracts the babel setup helper into its own module for easy consumption by other addons.