### PR TITLE
Decorator as class property fails with babel@7

### DIFF
--- a/private/setup-babel.js
+++ b/private/setup-babel.js
@@ -64,7 +64,10 @@ module.exports = function setupBabel(parent) {
     }
 
     if (!hasPlugin('@babel/plugin-proposal-class-properties')) {
-      plugins.push(requireTransform('@babel/plugin-proposal-class-properties'));
+      plugins.push([
+        requireTransform('@babel/plugin-proposal-class-properties'),
+        { loose: true }
+      ]);
     }
   } else {
     parent.project.ui.writeWarnLine(

--- a/tests/babel/class-decorators-legacy-and-class-properties-test.js
+++ b/tests/babel/class-decorators-legacy-and-class-properties-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+
+module('Babel | decorators (legacy) and class properties together ');
+
+// This test more or less only checks, if the `@decorator` syntax can be used.
+
+test('decorators inside class and class field work.', function(assert) {
+  function decorator(value) {
+    assert.strictEqual(value, 123);
+    return function() {};
+  }
+
+  class Foo {
+    @decorator(123)
+    bar = 'baz'
+
+  }
+
+  new Foo();
+});
+


### PR DESCRIPTION
This blows up:

```javascript
  class Foo {
    @decorator(123)
    bar = 'baz'

  }
```